### PR TITLE
Adding splitany helper

### DIFF
--- a/stringsutil.go
+++ b/stringsutil.go
@@ -156,3 +156,27 @@ func SplitAny(s string, seps ...string) []string {
 	}
 	return strings.FieldsFunc(s, splitter)
 }
+
+func SlideWithLength(s string, l int) chan string {
+	out := make(chan string)
+
+	go func(s string, l int) {
+		defer close(out)
+
+		if len(s) < l {
+			out <- s
+			return
+		}
+
+		for i := 0; i < len(s); i++ {
+			if i+l <= len(s) {
+				out <- s[i : i+l]
+			} else {
+				out <- s[i:]
+				break
+			}
+		}
+	}(s, l)
+
+	return out
+}

--- a/stringsutil.go
+++ b/stringsutil.go
@@ -147,3 +147,12 @@ func IndexAt(s, sep string, n int) int {
 	}
 	return idx
 }
+
+// SplitAny string by a list of separators
+func SplitAny(s string, seps ...string) []string {
+	sepsStr := strings.Join(seps, "")
+	splitter := func(r rune) bool {
+		return strings.ContainsRune(sepsStr, r)
+	}
+	return strings.FieldsFunc(s, splitter)
+}

--- a/stringsutil.go
+++ b/stringsutil.go
@@ -157,6 +157,7 @@ func SplitAny(s string, seps ...string) []string {
 	return strings.FieldsFunc(s, splitter)
 }
 
+// SlideWithLength returns all the strings of the specified length while moving forward the extraction window
 func SlideWithLength(s string, l int) chan string {
 	out := make(chan string)
 

--- a/stringsutil_test.go
+++ b/stringsutil_test.go
@@ -206,3 +206,29 @@ func TestIndexAt(t *testing.T) {
 		require.Equalf(t, test.Result, res, "test: %s after: %d search: %s result: %d", str, test.After, test.Search, res)
 	}
 }
+
+type splitanytest struct {
+	Splitset []string
+	Result   interface{}
+}
+
+func TestSplitAny(t *testing.T) {
+	tests := map[string]splitanytest{
+		"a a b":        {Splitset: []string{" "}, Result: []string{"a", "a", "b"}},
+		"test1test2 3": {Splitset: []string{"1", "2", " "}, Result: []string{"test", "test", "3"}},
+	}
+	for str, test := range tests {
+		res := SplitAny(str, test.Splitset...)
+		require.Equalf(t, test.Result, res, "test: %s splitset: %v result: %v got: %v", str, test.Splitset, test.Result, res)
+	}
+}
+
+func TestSlideWithLength(t *testing.T) {
+	var res []string
+	c := SlideWithLength("test123", 4)
+	require.NotNil(t, c)
+	for cc := range c {
+		res = append(res, cc)
+	}
+	require.Equal(t, []string{"test", "est1", "st12", "t123", "123"}, res)
+}


### PR DESCRIPTION
## Description
This PR adds support for `splitany` and `slidewithlength` helpers:
- `splitany`: split a string by multiple separators
- `slidewithlength`: returns all progressive continuous strings of length x (defined as parameter)